### PR TITLE
Add showRedundant flag.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,16 @@
     </dependency>
   </dependencies>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>2.0.6</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <plugins>
       <plugin>

--- a/src/main/java/org/kuali/maven/plugins/graph/mojo/BaseGraphMojo.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/mojo/BaseGraphMojo.java
@@ -145,6 +145,15 @@ public abstract class BaseGraphMojo extends BaseMavenMojo {
 
     /**
      * <p>
+     * If true, redundant dependency edges are kept in the graph.
+     * </p>
+     *
+     * @parameter expression="${graph.showRedundant}" default-value="false"
+     */
+    private boolean showRedundant;
+
+    /**
+     * <p>
      * Determines how conflicts in the dependency tree are displayed. Valid options are <code>IGNORE</code>,
      * <code>LABEL</code>, and <code>SHOW</code>.
      * </p>
@@ -363,4 +372,11 @@ public abstract class BaseGraphMojo extends BaseMavenMojo {
         this.showTypes = showTypes;
     }
 
+    public boolean isShowRedundant() {
+        return showRedundant;
+    }
+
+    public void setShowRedundant(boolean showRedundant) {
+        this.showRedundant = showRedundant;
+    }
 }

--- a/src/main/java/org/kuali/maven/plugins/graph/mojo/MojoHelper.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/mojo/MojoHelper.java
@@ -476,15 +476,15 @@ public class MojoHelper {
             processors.add(new LinkedEdgeProcessor());
             if (conflicts == Conflicts.LABEL) {
                 logger.debug("labeling conflicts");
-                processors.add(new ReduceClutterProcessor());
+                processors.add(new ReduceClutterProcessor(gd));
                 processors.add(conflictsProcessor);
             } else if (conflicts == Conflicts.SHOW) {
                 logger.debug("showing conflicts");
-                processors.add(new ReduceClutterProcessor());
+                processors.add(new ReduceClutterProcessor(gd));
             } else if (conflicts == Conflicts.IGNORE) {
                 logger.debug("ignoring conflicts");
                 processors.add(conflictsProcessor);
-                processors.add(new ReduceClutterProcessor());
+                processors.add(new ReduceClutterProcessor(gd));
             }
             return processors;
         case FLAT:

--- a/src/main/java/org/kuali/maven/plugins/graph/pojo/GraphDescriptor.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/pojo/GraphDescriptor.java
@@ -55,6 +55,7 @@ public class GraphDescriptor {
     String description;
     String name;
     Row row;
+    Boolean showRedundant;
 
     public String getExecutable() {
         return executable;
@@ -328,4 +329,11 @@ public class GraphDescriptor {
         this.showClassifiers = showClassifiers;
     }
 
+    public Boolean getShowRedundant() {
+        return showRedundant;
+    }
+
+    public void setShowRedundant(Boolean showRedundant) {
+        this.showRedundant = showRedundant;
+    }
 }

--- a/src/main/java/org/kuali/maven/plugins/graph/processor/ReduceClutterProcessor.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/processor/ReduceClutterProcessor.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.kuali.maven.plugins.graph.pojo.Edge;
+import org.kuali.maven.plugins.graph.pojo.GraphDescriptor;
 import org.kuali.maven.plugins.graph.pojo.GraphNode;
 import org.kuali.maven.plugins.graph.pojo.MavenContext;
 import org.kuali.maven.plugins.graph.pojo.State;
@@ -50,14 +51,20 @@ public class ReduceClutterProcessor implements Processor {
     private static final Logger logger = LoggerFactory.getLogger(ReduceClutterProcessor.class);
     // Track how many edges we remove
     int removeCount = 0;
+    Boolean showRedundant;
 
+    public ReduceClutterProcessor(GraphDescriptor gd) {
+        this.showRedundant = gd.getShowRedundant();
+    }
     /**
      * Process the tree
      */
     @Override
     public void process(Node<MavenContext> node) {
-        recurse(node);
-        logger.debug("removed {} redundant edges", removeCount);
+        if (!Boolean.TRUE.equals(showRedundant)) {
+            recurse(node);
+            logger.debug("removed {} redundant edges", removeCount);
+        }
     }
 
     /**


### PR DESCRIPTION
To illustrate the actual code dependencies in a project (especially when
enforcing total dependency definition using e.g. the dependency plugin),
it is necessary to have all edges from projects to dependencies present.

Currently, in a dependency tree like this:

```
            A
           / \
          B   C
         /
        C
```

the graph plugin will only plot

```
           A
           |
           B
           |
           C
```

This pull request adds a flag that will not remove any "redundant"
edges, so the result will be

```
           A
          / \
         B   |
          \ /
           C
```

While these graphs are more cluttered, they are also very useful to
fully grok dependencies in large Maven projects.
