### PR TITLE
Allow style properties override from pom.

### DIFF
--- a/src/main/java/org/kuali/maven/plugins/graph/dot/EdgeGenerator.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/dot/EdgeGenerator.java
@@ -18,6 +18,7 @@ package org.kuali.maven.plugins.graph.dot;
 import java.util.ArrayList;
 
 import org.kuali.maven.plugins.graph.pojo.Edge;
+import org.kuali.maven.plugins.graph.pojo.GraphDescriptor;
 import org.kuali.maven.plugins.graph.pojo.GraphNode;
 import org.kuali.maven.plugins.graph.pojo.MavenContext;
 import org.kuali.maven.plugins.graph.pojo.Scope;
@@ -34,8 +35,12 @@ import org.kuali.maven.plugins.graph.util.Counter;
  * </p>
  */
 public class EdgeGenerator {
-    StyleProcessor sp = new StyleProcessor();
+    StyleProcessor sp;
     Counter counter = new Counter(1);
+
+    public EdgeGenerator(GraphDescriptor gd) {
+        this.sp = new StyleProcessor(gd);
+    }
 
     /**
      * <p>

--- a/src/main/java/org/kuali/maven/plugins/graph/mojo/FilteredGraphMojo.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/mojo/FilteredGraphMojo.java
@@ -16,6 +16,7 @@
 package org.kuali.maven.plugins.graph.mojo;
 
 import java.io.File;
+import java.util.Properties;
 
 import org.kuali.maven.plugins.graph.pojo.Layout;
 
@@ -227,6 +228,13 @@ public abstract class FilteredGraphMojo extends BaseGraphMojo {
      */
     private int depth;
 
+    /**
+     * Allows overriding of the various style properties used to render the graph.
+     *
+     * @parameter
+     */
+    private Properties styleProperties = new Properties();
+
     public boolean isTransitive() {
         return transitive;
     }
@@ -283,4 +291,11 @@ public abstract class FilteredGraphMojo extends BaseGraphMojo {
         this.depth = depth;
     }
 
+    public Properties getStyleProperties() {
+        return styleProperties;
+    }
+
+    public void setStyleProperties(Properties styleProperties) {
+        this.styleProperties = styleProperties;
+    }
 }

--- a/src/main/java/org/kuali/maven/plugins/graph/mojo/MojoHelper.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/mojo/MojoHelper.java
@@ -389,7 +389,7 @@ public class MojoHelper {
         processors.add(getDisplayProcessor(gd));
 
         // Style the nodes based on scope, optional/required, and state
-        processors.add(new StyleProcessor());
+        processors.add(new StyleProcessor(gd));
 
         // Generate lines connecting the tree nodes
         processors.addAll(getEdgeProcessors(gd));
@@ -473,7 +473,7 @@ public class MojoHelper {
         Processor conflictsProcessor = new HideConflictsProcessor(gd);
         switch (gd.getLayout()) {
         case LINKED:
-            processors.add(new LinkedEdgeProcessor());
+            processors.add(new LinkedEdgeProcessor(gd));
             if (conflicts == Conflicts.LABEL) {
                 logger.debug("labeling conflicts");
                 processors.add(new ReduceClutterProcessor());
@@ -488,7 +488,7 @@ public class MojoHelper {
             }
             return processors;
         case FLAT:
-            processors.add(new FlatEdgeProcessor());
+            processors.add(new FlatEdgeProcessor(gd));
             if (conflicts == Conflicts.LABEL) {
                 logger.debug("labeling conflicts");
                 processors.add(conflictsProcessor);

--- a/src/main/java/org/kuali/maven/plugins/graph/pojo/GraphDescriptor.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/pojo/GraphDescriptor.java
@@ -16,6 +16,7 @@
 package org.kuali.maven.plugins.graph.pojo;
 
 import java.io.File;
+import java.util.Properties;
 
 /**
  *
@@ -55,6 +56,7 @@ public class GraphDescriptor {
     String description;
     String name;
     Row row;
+    Properties styleProperties;
 
     public String getExecutable() {
         return executable;
@@ -328,4 +330,11 @@ public class GraphDescriptor {
         this.showClassifiers = showClassifiers;
     }
 
+    public Properties getStyleProperties() {
+        return styleProperties;
+    }
+
+    public void setStyleProperties(Properties styleProperties) {
+        this.styleProperties = styleProperties;
+    }
 }

--- a/src/main/java/org/kuali/maven/plugins/graph/processor/FlatEdgeProcessor.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/processor/FlatEdgeProcessor.java
@@ -17,11 +17,16 @@ package org.kuali.maven.plugins.graph.processor;
 
 import org.kuali.maven.plugins.graph.dot.EdgeGenerator;
 import org.kuali.maven.plugins.graph.pojo.Edge;
+import org.kuali.maven.plugins.graph.pojo.GraphDescriptor;
 import org.kuali.maven.plugins.graph.pojo.MavenContext;
 import org.kuali.maven.plugins.graph.tree.Node;
 
 public class FlatEdgeProcessor implements Processor {
-    EdgeGenerator generator = new EdgeGenerator();
+    EdgeGenerator generator;
+
+    public FlatEdgeProcessor(GraphDescriptor gd) {
+        this.generator = new EdgeGenerator(gd);
+    }
 
     @Override
     public void process(Node<MavenContext> node) {

--- a/src/main/java/org/kuali/maven/plugins/graph/processor/HideConflictsProcessor.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/processor/HideConflictsProcessor.java
@@ -28,16 +28,13 @@ import org.kuali.maven.plugins.graph.tree.TreeHelper;
 
 public class HideConflictsProcessor implements Processor {
     TreeHelper helper = new TreeHelper();
-    EdgeGenerator generator = new EdgeGenerator();
+    EdgeGenerator generator;
     GraphDescriptor descriptor;
-
-    public HideConflictsProcessor() {
-        this(null);
-    }
 
     public HideConflictsProcessor(GraphDescriptor descriptor) {
         super();
         this.descriptor = descriptor;
+        this.generator = new EdgeGenerator(descriptor);
     }
 
     @Override

--- a/src/main/java/org/kuali/maven/plugins/graph/processor/LinkedEdgeProcessor.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/processor/LinkedEdgeProcessor.java
@@ -17,6 +17,7 @@ package org.kuali.maven.plugins.graph.processor;
 
 import org.kuali.maven.plugins.graph.dot.EdgeGenerator;
 import org.kuali.maven.plugins.graph.pojo.Edge;
+import org.kuali.maven.plugins.graph.pojo.GraphDescriptor;
 import org.kuali.maven.plugins.graph.pojo.GraphNode;
 import org.kuali.maven.plugins.graph.pojo.MavenContext;
 import org.kuali.maven.plugins.graph.pojo.Scope;
@@ -29,7 +30,11 @@ import org.slf4j.LoggerFactory;
 public class LinkedEdgeProcessor implements Processor {
     private static final Logger logger = LoggerFactory.getLogger(LinkedEdgeProcessor.class);
     public static final String REPLACEMENT_LABEL = "replacement";
-    EdgeGenerator generator = new EdgeGenerator();
+    EdgeGenerator generator;
+
+    public LinkedEdgeProcessor(GraphDescriptor gd) {
+        this.generator = new EdgeGenerator(gd);
+    }
 
     @Override
     public void process(Node<MavenContext> node) {

--- a/src/main/resources/dot.properties
+++ b/src/main/resources/dot.properties
@@ -22,41 +22,93 @@
 # fillcolor=white
 # weight=1.0
 # fontsize=8
-# style=solid,fitted
+# style=solid
 
 # 'state' properties override 'scope' properties and both override 'optional' properties
 
 # Node's can be in 1 of 5 states: included, conflict, duplicate, cyclic, or unknown
-#state.included.color=black
-#state.included.fontcolor=black
+state.included.color=
+state.included.fontcolor=
+state.included.fillcolor=
+state.included.weight=
+state.included.fontsize=
+state.included.style=
+#
 state.duplicate.color=#7C7D85
 state.duplicate.fontcolor=#7C7D85
+state.duplicate.fillcolor=white
+state.duplicate.weight=1.0
+state.duplicate.fontsize=8
+state.duplicate.style=solid
+#
 state.conflict.color=#F8161C
 state.conflict.fontcolor=#F8161C
 state.conflict.fillcolor=#EACFA4
+state.conflict.weight=1.0
+state.conflict.fontsize=8
+state.conflict.style=solid
+#
 state.cyclic.color=#D55A24
 state.cyclic.fontcolor=#000000
 state.cyclic.fillcolor=#8FBCA4
+state.cyclic.weight=1.0
+state.cyclic.fontsize=8
+state.cyclic.style=solid
+#
 state.unknown.color=#000000
 state.unknown.fontcolor=#000000
 state.unknown.fillcolor=#87DDEF
+state.unknown.weight=1.0
+state.unknown.fontsize=8
+state.unknown.style=solid
 
 # Dependencies can have 1 of 6 scopes: compile,test,runtime,provided,system,import
-#scope.compile.color=black
-#scope.compile.fontcolor=black
+scope.compile.color=
+scope.compile.fontcolor=
+scope.compile.fillcolor=
+scope.compile.weight=
+scope.compile.fontsize=
+scope.compile.style=
+#
 scope.test.color=#0A64C8
 scope.test.fontcolor=#0A64C8
+scope.test.fillcolor=white
+scope.test.weight=1.0
+scope.test.fontsize=8
+scope.test.style=solid
+#
 scope.provided.color=#F7B13D
 scope.provided.fontcolor=#F7B13D
+scope.provided.fillcolor=white
+scope.provided.weight=1.0
+scope.provided.fontsize=8
+scope.provided.style=solid
+#
 scope.runtime.color=#758B00
 scope.runtime.fontcolor=#758B00
+scope.runtime.fillcolor=white
+scope.runtime.weight=1.0
+scope.runtime.fontsize=8
+scope.runtime.style=solid
+#
 scope.system.color=#C30914
 scope.system.fontcolor=#C30914
+scope.system.fillcolor=white
+scope.system.weight=1.0
+scope.system.fontsize=8
+scope.system.style=solid
+#
 scope.import.color=#DF5920
 scope.import.fontcolor=#DF5920
+scope.import.fillcolor=white
+scope.import.weight=1.0
+scope.import.fontsize=8
+scope.import.style=solid
 
 # Dependencies can also be marked as optional
-optional.style=dotted
 optional.color=#7C7D85
 optional.fontcolor=#7C7D85
-
+optional.fillcolor=white
+optional.weight=1.0
+optional.fontsize=8
+optional.style=dotted


### PR DESCRIPTION
This adds a new property section to the configuration,  which allows
overriding any property that is listed in the dot.properties file. This
is especially useful if graphs need to match some corporate guidelines.

e.g. using

``` xml
           <styleProperties>
              <property>
                <name>scope.runtime.color</name>
                <value>black</value>
              </property>
              <property>
                <name>scope.runtime.fontcolor</name>
                <value>black</value>
              </property>
            </styleProperties>
```

to change the color of "runtime" edges.
