### PR TITLE
Definition of background-colors for nodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
   <description>Create customizable dependency graphs for Maven projects using Graphviz.  The Graphviz "dot" executable needs to be installed and in your path for the plugin to produce graphs - http://www.graphviz.org/</description>
   <dependencies>
     <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>2.0.6</version>
+    </dependency>
+    <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
       <version>1.8.3</version>

--- a/src/main/java/org/kuali/maven/plugins/graph/mojo/BaseGraphMojo.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/mojo/BaseGraphMojo.java
@@ -227,6 +227,29 @@ public abstract class BaseGraphMojo extends BaseMavenMojo {
      */
     private boolean skipEmptyGraphs;
 
+    /**
+     * <p>
+     * Default node-backgroundcolor if colorRules yield to no result (e.g. white or #000 or #000000)
+     * </p>
+     *
+     * @parameter expression="${graph.defaultColor}" default-value="white"
+     */
+    private String defaultColor;
+
+    /**
+     * <p>
+     * Configuration of rules for node-backgroundcolors. e.g. ARTIFACT|api|yellow:GROUP|apache|red <br/>
+     * <ul>
+     *   <li>ARTIFACT|api|yellow => Use yellow as color for nodes with ARTIFACT-name containing "api"</li>
+     *   <li>GROUP|apache|red => use red as color for nodes with GROUP-name containing "apache"</li>
+     *   <li>if more than one rule matches => background-color will be striped</li>
+     * </ul>
+     * </p>
+     *
+     * @parameter expression="${graph.colorConfig}"
+     */
+    private String colorRules;
+
     public String getTitle() {
         return title;
     }
@@ -315,6 +338,22 @@ public abstract class BaseGraphMojo extends BaseMavenMojo {
         this.skipEmptyGraphs = skipEmptyGraphs;
     }
 
+    public String getDefaultColor() {
+        return defaultColor;
+    }
+
+    public void setDefaultColor(String defaultColor) {
+        this.defaultColor = defaultColor;
+    }
+
+    public String getColorRules() {
+        return colorRules;
+    }
+
+    public void setColorRules(String colorRules) {
+        this.colorRules = colorRules;
+    }
+
     public Display getDisplay() {
         return display;
     }
@@ -362,5 +401,4 @@ public abstract class BaseGraphMojo extends BaseMavenMojo {
     public void setShowTypes(boolean showTypes) {
         this.showTypes = showTypes;
     }
-
 }

--- a/src/main/java/org/kuali/maven/plugins/graph/mojo/MojoHelper.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/mojo/MojoHelper.java
@@ -53,6 +53,7 @@ import org.kuali.maven.plugins.graph.pojo.MojoContext;
 import org.kuali.maven.plugins.graph.pojo.Row;
 import org.kuali.maven.plugins.graph.pojo.Scope;
 import org.kuali.maven.plugins.graph.processor.CascadeOptionalProcessor;
+import org.kuali.maven.plugins.graph.processor.ColorProcessor;
 import org.kuali.maven.plugins.graph.processor.FlatEdgeProcessor;
 import org.kuali.maven.plugins.graph.processor.HideConflictsProcessor;
 import org.kuali.maven.plugins.graph.processor.HideDuplicatesProcessor;
@@ -390,6 +391,9 @@ public class MojoHelper {
 
         // Style the nodes based on scope, optional/required, and state
         processors.add(new StyleProcessor());
+
+        // Colorize the nodes
+        processors.add(new ColorProcessor(gd));
 
         // Generate lines connecting the tree nodes
         processors.addAll(getEdgeProcessors(gd));

--- a/src/main/java/org/kuali/maven/plugins/graph/pojo/GraphDescriptor.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/pojo/GraphDescriptor.java
@@ -43,6 +43,8 @@ public class GraphDescriptor {
     Boolean executeDot;
     Boolean ignoreDotFailure;
     Boolean skipEmptyGraphs;
+    String defaultColor;
+    String colorRules;
     Integer depth;
     Scope scope;
     File file;
@@ -240,6 +242,22 @@ public class GraphDescriptor {
         this.skipEmptyGraphs = skipEmptyGraphs;
     }
 
+    public String getDefaultColor() {
+        return defaultColor;
+    }
+
+    public void setDefaultColor(String defaultColor) {
+        this.defaultColor = defaultColor;
+    }
+
+    public String getColorRules() {
+        return colorRules;
+    }
+
+    public void setColorRules(String colorRules) {
+        this.colorRules = colorRules;
+    }
+
     public Display getDisplay() {
         return display;
     }
@@ -327,5 +345,4 @@ public class GraphDescriptor {
     public void setShowClassifiers(Boolean showClassifiers) {
         this.showClassifiers = showClassifiers;
     }
-
 }

--- a/src/main/java/org/kuali/maven/plugins/graph/pojo/GraphNode.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/pojo/GraphNode.java
@@ -25,7 +25,7 @@ public class GraphNode {
     String color = "black";
     String fontcolor = "black";
     String fillcolor = "white";
-    String style = "solid,filled";
+    String style = "solid,striped";
     List<Edge> edges;
 
     public int getId() {

--- a/src/main/java/org/kuali/maven/plugins/graph/pojo/NameValueColor.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/pojo/NameValueColor.java
@@ -15,18 +15,15 @@
  */
 package org.kuali.maven.plugins.graph.pojo;
 
-public class NameValue {
+public class NameValueColor {
     String name;
     String value;
+    String color;
 
-    public NameValue() {
-        this(null, null);
-    }
-
-    public NameValue(String name, String value) {
-        super();
+    public NameValueColor(String name, String value, String color) {
         this.name = name;
         this.value = value;
+        this.color = color;
     }
 
     public String getName() {
@@ -43,5 +40,13 @@ public class NameValue {
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
     }
 }

--- a/src/main/java/org/kuali/maven/plugins/graph/processor/ColorProcessor.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/processor/ColorProcessor.java
@@ -1,0 +1,80 @@
+package org.kuali.maven.plugins.graph.processor;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.shared.dependency.tree.DependencyNode;
+import org.kuali.maven.plugins.graph.pojo.GraphDescriptor;
+import org.kuali.maven.plugins.graph.pojo.GraphNode;
+import org.kuali.maven.plugins.graph.pojo.MavenContext;
+import org.kuali.maven.plugins.graph.tree.Node;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.commons.lang.StringUtils.join;
+import static org.kuali.maven.plugins.graph.processor.ColorRuleExtractor.ColorPatternTarget;
+import static org.kuali.maven.plugins.graph.processor.ColorRuleExtractor.ColorRule;
+
+public class ColorProcessor implements Processor {
+
+    public static final String ROOT_FILL_COLOR = "#dddddd"; // abloesen und durch default-Farbe.darker ersetzen
+
+    private static final Logger logger = LoggerFactory.getLogger(ColorProcessor.class);
+
+    String defaultColor;
+    List<ColorRule> colorRules = new ArrayList<ColorRule>();
+
+    public ColorProcessor(GraphDescriptor graphDescriptor) {
+        defaultColor = graphDescriptor.getDefaultColor();
+        colorRules = new ColorRuleExtractor().getColorRules(graphDescriptor.getColorRules());
+    }
+
+    @Override
+    public void process(Node<MavenContext> node) {
+        for (Node<MavenContext> element : node.getBreadthFirstList()) {
+            updateGraphNodeColor(element.getObject());
+        }
+    }
+
+    public void updateGraphNodeColor(MavenContext context) {
+        DependencyNode dn = context.getDependencyNode();
+        GraphNode n = context.getGraphNode();
+        n.setFillcolor(getFillColor(dn, n));
+    }
+
+    private String getFillColor(DependencyNode dn, GraphNode n) {
+        if (dn.getParent() == null) {
+            return ROOT_FILL_COLOR;
+        }
+        List<String> colors = new ArrayList<String>();
+        for (ColorRule colorRule : colorRules) {
+            Artifact artifact = dn.getArtifact();
+            if (getTargetValue(colorRule.target, artifact).contains(colorRule.pattern)) {
+                colors.add(colorRule.color);
+            }
+        }
+        if (colors.isEmpty()) {
+            return defaultColor;
+        }
+        return join(colors, ":");
+    }
+
+    private String getTargetValue(ColorPatternTarget target, Artifact artifact) {
+        switch (target) {
+            case ARTIFACT:
+                return artifact.getArtifactId();
+            case GROUP:
+                return artifact.getGroupId();
+            case VERSION:
+                return artifact.getVersion();
+            case SCOPE:
+                return artifact.getScope();
+            case TYPE:
+                return artifact.getType();
+            case CLASSIFIER:
+                return artifact.getClassifier();
+        }
+        throw new IllegalStateException("target=" + target + " not supported");
+    }
+}

--- a/src/main/java/org/kuali/maven/plugins/graph/processor/ColorRuleExtractor.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/processor/ColorRuleExtractor.java
@@ -1,0 +1,62 @@
+package org.kuali.maven.plugins.graph.processor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.commons.lang.StringUtils.split;
+
+public class ColorRuleExtractor {
+    public List<ColorRule> getColorRules(String colorRules) {
+        List<ColorRule> result = new ArrayList<ColorRule>();
+        if (colorRules == null) {
+            return result;
+        }
+        try {
+            for (String rule : split(colorRules, ":")) {
+                String[] split = split(rule, "|");
+                if (split != null && split.length == 3) {
+                    result.add(new ColorRule(
+                        ColorPatternTarget.valueOf(split[0]),
+                        split[1],
+                        split[2]
+                    ));
+                }
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("colorRules not correctly configured: format: " + getFormat());
+        }
+        return result;
+    }
+
+    private String getFormat() {
+        return "target|searchPattern|color:target2|searchPettern2|color2:...:targetN|searchPatternN|colorN  (with target in (ARTIFACT, GROUP, VERSION, SCOPE, TYPE, CLASSIFIER))";
+    }
+
+    public static class ColorRule {
+        ColorPatternTarget target;
+        String pattern;
+        String color;
+
+        private ColorRule(ColorPatternTarget target, String pattern, String color) {
+            this.target = target;
+            this.pattern = pattern;
+            this.color = color;
+        }
+
+        public ColorPatternTarget getTarget() {
+            return target;
+        }
+
+        public String getPattern() {
+            return pattern;
+        }
+
+        public String getColor() {
+            return color;
+        }
+    }
+
+    public enum ColorPatternTarget {
+        ARTIFACT, GROUP, VERSION, SCOPE, TYPE, CLASSIFIER
+    }
+}

--- a/src/main/java/org/kuali/maven/plugins/graph/processor/StyleProcessor.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/processor/StyleProcessor.java
@@ -132,9 +132,9 @@ public class StyleProcessor implements Processor {
         }
         copyStyleProperties(context.getGraphNode(), style);
         if (optional) {
-            context.getGraphNode().setStyle("dotted,filled");
+            context.getGraphNode().setStyle("dotted,striped");
         } else {
-            context.getGraphNode().setStyle("solid,filled");
+            context.getGraphNode().setStyle("solid,striped");
         }
     }
 

--- a/src/main/java/org/kuali/maven/plugins/graph/tree/TreeHelper.java
+++ b/src/main/java/org/kuali/maven/plugins/graph/tree/TreeHelper.java
@@ -51,7 +51,6 @@ import org.springframework.util.Assert;
  */
 public class TreeHelper {
     private static final Logger logger = LoggerFactory.getLogger(TreeHelper.class);
-    public static final String ROOT_FILL_COLOR = "#dddddd";
     public static final String OPTIONAL = "optional";
     public static final String REQUIRED = "required";
     Counter counter = new Counter();
@@ -407,8 +406,6 @@ public class TreeHelper {
         GraphNode n = new GraphNode();
         n.setId(counter.increment());
         n.setLabel(graphHelper.getLabel(a));
-        String fillcolor = dn.getParent() == null ? ROOT_FILL_COLOR : n.getFillcolor();
-        n.setFillcolor(fillcolor);
         return n;
     }
 


### PR DESCRIPTION
**Description**
Allows definition of background-colors for nodes based on name of mvn artifact, group, version, scope, type or classifier.
Configuration is displayed in legend.

**Sample-Command (executed from Plugin-directory):**
mvn org.kuali.maven.plugins:graph-maven-plugin:1.2.4-SNAPSHOT:dependencies "-Dgraph.colorConfig=ARTIFACT|api|yellow:GROUP|apache|red" -Dgraph.verbose=true -Dgraph.direction=LR -Dgraph.file=dependencies.pdf

**Result:**
[dependencies.pdf](https://github.com/jcaddel/graph-maven-plugin/files/225633/dependencies.pdf)
